### PR TITLE
feat: Complete CRUD operations for Tag management

### DIFF
--- a/src/main/java/org/example/komflow/features/contact/controller/TagController.java
+++ b/src/main/java/org/example/komflow/features/contact/controller/TagController.java
@@ -4,6 +4,8 @@ import jakarta.validation.Valid;
 import org.example.komflow.features.contact.dto.TagDto;
 import org.example.komflow.features.contact.service.TagService;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,5 +27,22 @@ public class TagController {
     @GetMapping
     public List<TagDto> getAll() {
         return tagService.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public TagDto getById(@PathVariable Long id) {
+        return tagService.getById(id);
+    }
+
+    @PutMapping("/{id}")
+    public TagDto update(@PathVariable Long id, @Valid @RequestBody TagDto tagDto) {
+        tagDto.setId(id);
+        return tagService.update(tagDto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        tagService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
This commit finalizes the Tag management feature by implementing the remaining REST endpoints in TagController:
- GET /api/v1/tag/{id} (getById)
- PUT /api/v1/tag/{id} (update)
- DELETE /api/v1/tag/{id} (delete)

The TagService, TagRepository, TagDto, and TagMapper were reviewed and found to be mostly complete and correct. Minor adjustments in the controller ensure proper delegation to the service layer and handling of path variables.

Validation using @Valid is applied for create and update operations. EntityNotFoundException is consistently used in the service layer and handled by the global RestExceptionHandler to return 404 responses.