### PR TITLE
feat: Standardize validation messages to i18n keys (Partial)

### DIFF
--- a/src/main/java/org/example/komflow/features/contact/dto/ContactDto.java
+++ b/src/main/java/org/example/komflow/features/contact/dto/ContactDto.java
@@ -1,0 +1,31 @@
+package org.example.komflow.features.contact.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+// Assuming TagDto is in the same package, otherwise add import
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactDto {
+
+    private Long id;
+
+    private boolean enabled;
+
+    private Instant lastMessageReceivedAt;
+
+    @NotNull(message = "contact.personId.notNull")
+    private Long personId; // Representing the Person relationship
+
+    private List<TagDto> tags; // Using existing TagDto
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/contact/dto/TagDto.java
+++ b/src/main/java/org/example/komflow/features/contact/dto/TagDto.java
@@ -1,20 +1,20 @@
 package org.example.komflow.features.contact.dto;
 
-import jakarta.validation.constraints.NotBlank; // Import added
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
 public class TagDto {
-    private Long id; // Changed from String to Long
+    private Long id;
 
-    @NotBlank // Added
+    @NotBlank(message = "tag.name.notBlank")
     private String name;
 
     private String description;
 
-    @NotBlank // Added
+    @NotBlank(message = "tag.colorCode.notBlank")
     private String colorCode;
 
     private Instant createdAt;

--- a/src/main/java/org/example/komflow/features/core/dto/FileDto.java
+++ b/src/main/java/org/example/komflow/features/core/dto/FileDto.java
@@ -1,0 +1,29 @@
+package org.example.komflow.features.core.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+// Removed unused NotNull import from previous version
+import org.hibernate.validator.constraints.URL;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FileDto {
+
+    private Long id;
+
+    @NotBlank(message = "file.name.notBlank")
+    private String name;
+
+    @NotBlank(message = "file.url.notBlank")
+    @URL(message = "file.url.invalidFormat")
+    private String url;
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/messaging/dto/CampaignDto.java
+++ b/src/main/java/org/example/komflow/features/messaging/dto/CampaignDto.java
@@ -1,0 +1,39 @@
+package org.example.komflow.features.messaging.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import org.example.komflow.features.contact.dto.ContactDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CampaignDto {
+
+    private Long id;
+
+    @NotBlank(message = "campaign.name.notBlank")
+    @Size(max = 255, message = "campaign.name.sizeExceeded") // Assuming max=255 is the only size constraint
+    private String name;
+
+    private String description;
+
+    @NotNull(message = "campaign.messageId.notNull")
+    private Long messageId; // Representing the Message relationship
+
+    private List<ContactDto> contacts;
+
+    private List<ContactDto> mailCc;
+
+    private List<ContactDto> mailCci;
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/messaging/dto/MessageDto.java
+++ b/src/main/java/org/example/komflow/features/messaging/dto/MessageDto.java
@@ -1,0 +1,32 @@
+package org.example.komflow.features.messaging.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import org.example.komflow.features.core.dto.FileDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageDto {
+
+    private Long id;
+
+    @NotBlank(message = "message.title.notBlank")
+    @Size(max = 255, message = "message.title.sizeExceeded")
+    private String title;
+
+    @NotBlank(message = "message.body.notBlank")
+    private String body;
+
+    private List<FileDto> attachments; // Using existing FileDto
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/personnel/dto/PersonDto.java
+++ b/src/main/java/org/example/komflow/features/personnel/dto/PersonDto.java
@@ -1,0 +1,38 @@
+package org.example.komflow.features.personnel.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PersonDto {
+
+    private Long id;
+
+    @Email(message = "person.email.invalidFormat")
+    @Size(max = 255, message = "person.email.sizeExceeded")
+    private String email;
+
+    @NotBlank(message = "person.firstName.notBlank")
+    @Size(max = 100, message = "person.firstName.sizeExceeded")
+    private String firstName;
+
+    @NotBlank(message = "person.lastName.notBlank")
+    @Size(max = 100, message = "person.lastName.sizeExceeded")
+    private String lastName;
+
+    @Size(max = 50, message = "person.language.sizeExceeded")
+    private String language;
+
+    private List<PhoneNumberDto> phoneNumbers; // Embed PhoneNumberDto
+
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/personnel/dto/PhoneNumberDto.java
+++ b/src/main/java/org/example/komflow/features/personnel/dto/PhoneNumberDto.java
@@ -1,0 +1,30 @@
+package org.example.komflow.features.personnel.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhoneNumberDto {
+
+    private Long id;
+
+    @NotBlank(message = "phoneNumber.number.notBlank")
+    @Size(max = 50, message = "phoneNumber.number.sizeExceeded")
+    private String number;
+
+    @Size(max = 10, message = "phoneNumber.isWhatsapp.sizeExceeded")
+    private String isWhatsapp;
+
+    private Long personId; // ID of the associated Person
+    private Long contactId; // ID of the associated Contact
+
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/personnel/dto/UserDto.java
+++ b/src/main/java/org/example/komflow/features/personnel/dto/UserDto.java
@@ -1,0 +1,37 @@
+package org.example.komflow.features.personnel.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+
+    private Long id;
+
+    @NotBlank(message = "user.username.notBlank")
+    @Size(min = 3, max = 100, message = "user.username.size")
+    private String username;
+
+    // Password is intentionally omitted for security reasons in response DTOs.
+    // For creation/update, specific DTOs or fields should be used.
+
+    private boolean enabled;
+
+    @NotNull(message = "user.person.notNull")
+    private PersonDto person; // Embed PersonDto
+
+    private List<Long> roleIds; // Placeholder for Role DTOs
+
+    // Audit logs (logs field) are omitted for brevity.
+
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/security/dto/AuditLogDto.java
+++ b/src/main/java/org/example/komflow/features/security/dto/AuditLogDto.java
@@ -1,0 +1,36 @@
+package org.example.komflow.features.security.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditLogDto {
+
+    private Long id;
+
+    @NotBlank(message = "Action cannot be blank")
+    @Size(max = 100, message = "Action cannot exceed 100 characters")
+    private String action;
+
+    @Size(max = 100, message = "Object type cannot exceed 100 characters")
+    private String objectType;
+
+    @Size(max = 100, message = "Object ID cannot exceed 100 characters")
+    private String objectId;
+
+    @Size(max = 50, message = "IP address cannot exceed 50 characters")
+    private String ipAddress;
+
+    @Size(max = 255, message = "User agent cannot exceed 255 characters")
+    private String userAgent;
+
+    private String details; // Could be large, so no size constraint for now
+
+    private Instant date; // Timestamp of the audit log
+}

--- a/src/main/java/org/example/komflow/features/security/dto/PermissionDto.java
+++ b/src/main/java/org/example/komflow/features/security/dto/PermissionDto.java
@@ -1,0 +1,26 @@
+package org.example.komflow.features.security.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PermissionDto {
+
+    private Long id;
+
+    @NotBlank(message = "Permission name cannot be blank")
+    @Size(max = 100, message = "Permission name cannot exceed 100 characters")
+    private String name;
+
+    @Size(max = 255, message = "Description cannot exceed 255 characters")
+    private String description;
+
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/org/example/komflow/features/security/dto/RoleDto.java
+++ b/src/main/java/org/example/komflow/features/security/dto/RoleDto.java
@@ -1,0 +1,29 @@
+package org.example.komflow.features.security.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleDto {
+
+    private Long id;
+
+    @NotBlank(message = "Role name cannot be blank")
+    @Size(max = 100, message = "Role name cannot exceed 100 characters")
+    private String name;
+
+    @Size(max = 255, message = "Description cannot exceed 255 characters")
+    private String description;
+
+    private List<PermissionDto> permissions; // Embed PermissionDto
+
+    private Instant createdAt;
+    private Instant updatedAt;
+}


### PR DESCRIPTION
This commit updates JSR 303 validation messages in several DTOs to use internationalization-friendly keys instead of hardcoded strings. This change supports easier translation on the frontend.

Updated DTOs:
- features/contact/dto/TagDto.java
- features/contact/dto/ContactDto.java
- features/core/dto/FileDto.java
- features/messaging/dto/CampaignDto.java
- features/messaging/dto/MessageDto.java
- features/personnel/dto/PhoneNumberDto.java
- features/personnel/dto/PersonDto.java
- features/personnel/dto/UserDto.java

Pending work:
- Update validation messages for AuditLogDto, PermissionDto, RoleDto.
- Create a standard ErrorResponseDto.
- Refactor RestExceptionHandler to use ErrorResponseDto and provide standardized error responses, including for validation failures (MethodArgumentNotValidException) by returning the i18n keys.
- Update UserDto to use List<RoleDto> instead of List<Long>.

This commit addresses your feedback regarding validation message formatting.